### PR TITLE
#423665 -  uk nation should not keep session after cancel

### DIFF
--- a/src/FrontendAccountManagement.Web.UnitTests/Controllers/AccountManagement/AccountManagementTests.cs
+++ b/src/FrontendAccountManagement.Web.UnitTests/Controllers/AccountManagement/AccountManagementTests.cs
@@ -318,6 +318,35 @@ public class AccountManagementTests : AccountManagementTestBase
     }
 
     [TestMethod]
+    public async Task GivenOnManageAccountPage_WhenTempDataHasSession_CheckYourOrganisationDetails_ShouldRemoveAnyTempData()
+    {
+        const string checkYourOrganisationDetailsKey = "CheckYourOrganisationDetails";
+        // Arrange
+        var checkYourOrganisationDetails = new CheckYourOrganisationDetailsViewModel
+        {
+            OrganisationId = Guid.NewGuid(),
+            UkNation = UkNation.England,
+        };
+
+        var userData = SetupUserData(string.Empty);
+
+        SetupBase(userData: userData);
+
+        SystemUnderTest.TempData.Add(checkYourOrganisationDetailsKey, JsonSerializer.Serialize(checkYourOrganisationDetails));
+
+        Assert.IsNotNull(SystemUnderTest.TempData[checkYourOrganisationDetailsKey]);
+
+        // Act
+        var result = await SystemUnderTest.ManageAccount(new ManageAccountViewModel()) as ViewResult;
+
+        // Assert
+        result.Should().BeOfType<ViewResult>();
+        result.ViewName.Should().Be(ViewName);
+        Assert.IsNull(SystemUnderTest.TempData[checkYourOrganisationDetailsKey]);
+    }
+
+
+    [TestMethod]
     public async Task GivenOnEditUserDetailsPage_WhenPageSubbmitedWithValidData_RedirectsToNextPage()
     {
         // Arrange

--- a/src/FrontendAccountManagement.Web.UnitTests/Controllers/AccountManagement/AccountManagementTests.cs
+++ b/src/FrontendAccountManagement.Web.UnitTests/Controllers/AccountManagement/AccountManagementTests.cs
@@ -318,7 +318,7 @@ public class AccountManagementTests : AccountManagementTestBase
     }
 
     [TestMethod]
-    public async Task GivenOnManageAccountPage_WhenTempDataHasSession_CheckYourOrganisationDetails_ShouldRemoveAnyTempData()
+    public async Task GivenOnManageAccountPage_WhenTempDataHasSession_CheckYourOrganisationDetails_ShouldRemoveTempData()
     {
         const string checkYourOrganisationDetailsKey = "CheckYourOrganisationDetails";
         // Arrange

--- a/src/FrontendAccountManagement.Web/Controllers/AccountManagement/AccountManagementController.cs
+++ b/src/FrontendAccountManagement.Web/Controllers/AccountManagement/AccountManagementController.cs
@@ -142,6 +142,8 @@ public class AccountManagementController : Controller
             });
         }
 
+        RemoveTempDataSessionsChangeDetails();
+
         session.AccountManagementSession.AddUserJourney = null;
         if (session.AccountManagementSession.RemoveUserStatus != null)
         {
@@ -1403,5 +1405,13 @@ public class AccountManagementController : Controller
 
         return roleInOrganisation == PersonRole.Admin.ToString() &&
             serviceRoleId == (int)ServiceRole.Basic;
+    }
+
+    private void RemoveTempDataSessionsChangeDetails()
+    {
+        if (TempData[CheckYourOrganisationDetailsKey] != null)
+        {
+            TempData.Remove(CheckYourOrganisationDetailsKey);
+        }
     }
 }


### PR DESCRIPTION
#423665 -  bug fix to remove active session after clicking cancel on company details check. This issue was affecting the UK-Nation page.