### PR TITLE
Only show change org link for Approved and Delegated users.

### DIFF
--- a/src/FrontendAccountManagement.Web/Controllers/AccountManagement/AccountManagementController.cs
+++ b/src/FrontendAccountManagement.Web/Controllers/AccountManagement/AccountManagementController.cs
@@ -1840,13 +1840,7 @@ public class AccountManagementController : Controller
 
     private static bool HasPermissionToChangeCompany(UserData userData)
     {
-        var roleInOrganisation = userData.RoleInOrganisation;
-        if ((userData.ServiceRoleId == (int)Core.Enums.ServiceRole.Approved || userData.ServiceRoleId == (int)Core.Enums.ServiceRole.Delegated)
-            && !string.IsNullOrEmpty(roleInOrganisation) && roleInOrganisation == PersonRole.Admin.ToString())
-        {
-            return true;
-        }
-        return false;
+        return userData.ServiceRoleId is (int)ServiceRole.Approved or (int)ServiceRole.Delegated;
     }
 
     private static bool IsApprovedOrDelegatedUser(UserData userData)


### PR DESCRIPTION
For reference, we have four user types but this is not exactly represented in code as you might expect. Below are four example users, the expected type and the value of the two properties (Role In Organisation and Service Role) that applies to each type of user.
![image](https://github.com/user-attachments/assets/46269383-5fe0-41de-90fc-8767f71f0948)

After discussion with Manish and Zozan, I have opted to ignore the Role In Organisation for the purposes of this check and just check if the Service Role is either Approved or Delegated.

I added a unit test to validate the possible combinations. Hopefully this should make it easier to change if my logic is incorrect or we need to make future changes.