### PR TITLE
session timeout issue

### DIFF
--- a/src/FrontendAccountManagement.Web/Views/Shared/Components/SessionTimeoutWarning/Default.cshtml
+++ b/src/FrontendAccountManagement.Web/Views/Shared/Components/SessionTimeoutWarning/Default.cshtml
@@ -7,4 +7,6 @@
     <div class="session-timeout-container" id="session-timeout-container-id">
         @await Html.PartialAsync("_TimeoutSessionWarning")
     </div>
+
+    <script src="~/js/sessionTimeout.js"></script>
 }

--- a/src/FrontendAccountManagement.Web/Views/Shared/_Layout.cshtml
+++ b/src/FrontendAccountManagement.Web/Views/Shared/_Layout.cshtml
@@ -95,7 +95,6 @@
     @await Html.PartialAsync("Partials/Govuk/_Footer", ExternalUrlsOptions.Value)
 
     <script src="~/js/govuk.js"></script>
-    <script src="~/js/sessionTimeout.js"></script>
     <script nonce="@scriptNonce">window.GOVUKFrontend.initAll()</script>
 
     @await RenderSectionAsync("Scripts", required: false)

--- a/src/FrontendAccountManagement.Web/Views/Shared/_TimeoutSessionWarning.cshtml
+++ b/src/FrontendAccountManagement.Web/Views/Shared/_TimeoutSessionWarning.cshtml
@@ -1,6 +1,6 @@
 <body>
     <!-- Timeout Modal -->
-    <div id="session-timeout-container-id" class="timeout-modal" role="dialog" aria-labelledby="timeout-title" aria-modal="true">
+    <div id="session-timeout-modal-id" class="timeout-modal" role="dialog" aria-labelledby="timeout-title" aria-modal="true">
         <div class="modal-content">
             <h1 id="timeout-title" class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">
                 @Localizer["You_will_be_signed_out_soon"]

--- a/src/FrontendAccountManagement.Web/appsettings.json
+++ b/src/FrontendAccountManagement.Web/appsettings.json
@@ -12,7 +12,7 @@
     "ShowLanguageSwitcher": false,
     "ManageUserDetailChanges": false,
     "ManageCompanyDetailChanges": true,
-    "ShowSessionTimeoutWarning": true
+    "ShowSessionTimeoutWarning": false
   },
   "PATH_BASE": "/manage-account",
   "ForwardedHeaders": {

--- a/src/FrontendAccountManagement.Web/assets/js/sessionTimeout.js
+++ b/src/FrontendAccountManagement.Web/assets/js/sessionTimeout.js
@@ -1,7 +1,6 @@
 ﻿const IDLE_TIMEOUT_MS = 17 * 60  * 1000; // 17 minutes before showing modal
 const LOGOUT_COUNTDOWN_DURATION = 120; // Logout countdown starts from 120 seconds
 const LOGOUT_REDIRECT_URL = "/manage-account/Account/SessionSignOut";
-const PING_URL = "/manage-account/Account/KeepSessionAlive"; // Endpoint to keep session alive
 
 let idleTimeout, logoutCountdown;
 
@@ -112,15 +111,7 @@ const SessionTimeoutManager = {
         this.toggleModalVisibility(false);
         clearInterval(logoutCountdown);
         this.resetIdleTimer();
-        this.keepSessionAlive();
-    },
-
-    async keepSessionAlive() {
-        try {
-            await fetch(PING_URL, { method: "GET"});
-        } catch (error) {
-            console.error("Failed to ping server:", error);
-        }
+        window.location.reload();
     }
 };
 


### PR DESCRIPTION
#540347
When a user is idle for 17 minutes, a session timeout notification will pops up and if the user clicked on the continue button, the expectation is that the user's session will be extended for another 17 to 20 minutes but currently this is not happening.

5 minutes after a user clicked on the 'Continue Button' on the session notification and the user clicks on another link on the page, the user is logged out instead of taking the user to their intended destination or page.