### PR TITLE
Introduce NullGraphService AB#611682

### DIFF
--- a/src/FrontendAccountManagement.Web/Extensions/NullGraphService.cs
+++ b/src/FrontendAccountManagement.Web/Extensions/NullGraphService.cs
@@ -1,0 +1,23 @@
+﻿using EPR.Common.Authorization.Services.Interfaces;
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FrontendAccountManagement.Web.Extensions;
+
+[ExcludeFromCodeCoverage]
+public class NullGraphService : IGraphService
+{
+    public static readonly NullGraphService Empty = new();
+
+    public Task PatchUserProperty(Guid userId, string propertyName, string value, CancellationToken cancellationToken = default)
+    {
+        return Task.CompletedTask;
+    }
+
+    public async Task<string?> QueryUserProperty(Guid userId, string propertyName, CancellationToken cancellationToken = default)
+    {
+        return null;
+    }
+}

--- a/src/FrontendAccountManagement.Web/Extensions/ServiceProviderExtension.cs
+++ b/src/FrontendAccountManagement.Web/Extensions/ServiceProviderExtension.cs
@@ -1,20 +1,21 @@
 ﻿using EPR.Common.Authorization.Extensions;
+using EPR.Common.Authorization.Extensions;
+using EPR.Common.Authorization.Services.Interfaces;
+using EPR.Common.Authorization.Sessions;
+using FrontendAccountManagement.Core.Services;
 using FrontendAccountManagement.Core.Sessions;
 using FrontendAccountManagement.Web.Configs;
 using FrontendAccountManagement.Web.Constants;
 using FrontendAccountManagement.Web.Cookies;
+using FrontendAccountManagement.Web.Middleware;
 using FrontendAccountManagement.Web.Sessions;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-using EPR.Common.Authorization.Extensions;
-using FrontendAccountManagement.Web.Middleware;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Identity.Web;
 using Microsoft.Identity.Web.TokenCacheProviders.Distributed;
 using StackExchange.Redis;
-using EPR.Common.Authorization.Sessions;
-using FrontendAccountManagement.Core.Services;
 
 namespace FrontendAccountManagement.Web.Extensions;
 
@@ -180,7 +181,7 @@ public static class ServiceProviderExtension
         }
         else
         {
-            services.RegisterNullGraphServiceClient();
+            services.AddTransient<IGraphService, NullGraphService>();
         }
 
         return services;

--- a/src/FrontendAccountManagement.Web/Middleware/UserDataCheckerMiddleware.cs
+++ b/src/FrontendAccountManagement.Web/Middleware/UserDataCheckerMiddleware.cs
@@ -4,6 +4,7 @@ using EPR.Common.Authorization.Services.Interfaces;
 using FrontendAccountManagement.Core.Services;
 using FrontendAccountManagement.Web.Configs;
 using FrontendAccountManagement.Web.Constants;
+using FrontendAccountManagement.Web.Extensions;
 using FrontendAccountManagement.Web.Utilities.Interfaces;
 using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.FeatureManagement;
@@ -74,7 +75,7 @@ public class UserDataCheckerMiddleware : IMiddleware
         }
 
         var organisationIds = string.Join(",", accountUser.Organisations.Select(o => o.OrganisationNumber));
-        if (organisationIds != orgIdsClaim && _graphService is not null)
+        if (organisationIds != orgIdsClaim && _graphService is not null && _graphService is not NullGraphService)
         {
             await _graphService.PatchUserProperty(accountUser.Id.Value, ExtensionClaims.OrganisationIdsExtensionClaimName, organisationIds);
             _logger.LogInformation("Patched {Type} with value {Value}", ExtensionClaims.OrganisationIdsExtensionClaimName, organisationIds);


### PR DESCRIPTION
Add a null graph service instance to fix crash when the UseGraphApiForExtendedUserClaims feature flag is off