### PR TITLE
Fixed UI issues as part of upgrade to govuk-frontend 5.11.1

### DIFF
--- a/src/FrontendAccountManagement.Web/Resources/Views/Shared/Components/PhaseBanner/Default.cy.resx
+++ b/src/FrontendAccountManagement.Web/Resources/Views/Shared/Components/PhaseBanner/Default.cy.resx
@@ -19,13 +19,13 @@
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
     <data name="PhaseBanner.Alpha" xml:space="preserve">
-        <value>alffa</value>
+        <value>Alffa</value>
     </data>
     <data name="PhaseBanner.Beta" xml:space="preserve">
-        <value>beta</value>
+        <value>Beta</value>
     </data>
     <data name="PhaseBanner.Live" xml:space="preserve">
-        <value>byw</value>
+        <value>Byw</value>
     </data>
     <data name="PhaseBanner.ThisIsNewService" xml:space="preserve">
         <value>Mae hwn yn wasanaeth newydd – bydd eich</value>

--- a/src/FrontendAccountManagement.Web/Resources/Views/Shared/Components/PhaseBanner/Default.en.resx
+++ b/src/FrontendAccountManagement.Web/Resources/Views/Shared/Components/PhaseBanner/Default.en.resx
@@ -19,13 +19,13 @@
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
     <data name="PhaseBanner.Alpha" xml:space="preserve">
-        <value>alpha</value>
+        <value>Alpha</value>
     </data>
     <data name="PhaseBanner.Beta" xml:space="preserve">
-        <value>beta</value>
+        <value>Beta</value>
     </data>
     <data name="PhaseBanner.Live" xml:space="preserve">
-        <value>live</value>
+        <value>Live</value>
     </data>
     <data name="PhaseBanner.ThisIsNewService" xml:space="preserve">
         <value>This is a new service – your</value>

--- a/src/FrontendAccountManagement.Web/ResourcesRegulator/Views/Shared/Components/PhaseBanner/Default.cy.resx
+++ b/src/FrontendAccountManagement.Web/ResourcesRegulator/Views/Shared/Components/PhaseBanner/Default.cy.resx
@@ -19,13 +19,13 @@
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
     <data name="PhaseBanner.Alpha" xml:space="preserve">
-        <value>alffa</value>
+        <value>Alffa</value>
     </data>
     <data name="PhaseBanner.Beta" xml:space="preserve">
-        <value>beta</value>
+        <value>Beta</value>
     </data>
     <data name="PhaseBanner.Live" xml:space="preserve">
-        <value>byw</value>
+        <value>Byw</value>
     </data>
     <data name="PhaseBanner.ThisIsNewService" xml:space="preserve">
         <value>Mae hwn yn wasanaeth newydd – bydd eich</value>

--- a/src/FrontendAccountManagement.Web/ResourcesRegulator/Views/Shared/Components/PhaseBanner/Default.en.resx
+++ b/src/FrontendAccountManagement.Web/ResourcesRegulator/Views/Shared/Components/PhaseBanner/Default.en.resx
@@ -19,13 +19,13 @@
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
     <data name="PhaseBanner.Alpha" xml:space="preserve">
-        <value>alpha</value>
+        <value>Alpha</value>
     </data>
     <data name="PhaseBanner.Beta" xml:space="preserve">
-        <value>beta</value>
+        <value>Beta</value>
     </data>
     <data name="PhaseBanner.Live" xml:space="preserve">
-        <value>live</value>
+        <value>Live</value>
     </data>
     <data name="PhaseBanner.ThisIsNewService" xml:space="preserve">
         <value>This is a new service – your</value>

--- a/src/FrontendAccountManagement.Web/Views/AccountManagement/CheckYourDetails.cshtml
+++ b/src/FrontendAccountManagement.Web/Views/AccountManagement/CheckYourDetails.cshtml
@@ -20,7 +20,7 @@
 
     <div class="govuk-width-container">
         <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
-            <h1 class="govuk-fieldset__heading govuk-label--l">
+            <h1 class="govuk-heading-l">
                 @Localizer["CheckYourDetails"]
             </h1>
 

--- a/src/FrontendAccountManagement.Web/Views/AccountManagement/TeamMemberDetails.cshtml
+++ b/src/FrontendAccountManagement.Web/Views/AccountManagement/TeamMemberDetails.cshtml
@@ -14,7 +14,7 @@
     <div class="govuk-width-container">
         <main class="govuk-main-wrapper govuk-!-padding-top-4" id="main-content" role="main">
             <div  id="teammemberdetails-wrapper">
-                <h1 class="govuk-fieldset__heading govuk-label--l">
+                <h1 class="govuk-heading-l">
                     @Localizer["CheckInvitationDetails"]
                 </h1>
                 <br/>

--- a/src/FrontendAccountManagement.Web/Views/PermissionManagement/ConfirmChangePermission.cshtml
+++ b/src/FrontendAccountManagement.Web/Views/PermissionManagement/ConfirmChangePermission.cshtml
@@ -27,7 +27,7 @@
             <div class="govuk-grid-column-two-thirds">
                 @await Html.PartialAsync("Partials/Govuk/_ErrorSummary", errorsViewModel)
                 
-                <h1 class="govuk-fieldset__heading govuk-label--l">
+                <h1 class="govuk-heading-l">
                     @Localizer["ConfirmChangePermission.Question"]
                 </h1>
 

--- a/src/FrontendAccountManagement.Web/Views/Shared/Partials/Govuk/_Header.cshtml
+++ b/src/FrontendAccountManagement.Web/Views/Shared/Partials/Govuk/_Header.cshtml
@@ -55,11 +55,11 @@
 			          <li class="govuk-header__navigation-item">
 				          @if (User.Identity?.IsAuthenticated == true)
 				          {
-					          <a class="govuk-header__link epr-sign-out-nav__link" asp-controller="Account" asp-action="SignOut">@SharedLocalizer["Regulator.SignOut"]</a>
+					          <a class="govuk-header__link" asp-controller="Account" asp-action="SignOut">@SharedLocalizer["Regulator.SignOut"]</a>
 				          }
 				          else
 				          {
-					          <a class="govuk-header__link epr-sign-out-nav__link" asp-controller="Account" asp-action="SignIn">@SharedLocalizer["Regulator.SignIn"]</a>
+					          <a class="govuk-header__link" asp-controller="Account" asp-action="SignIn">@SharedLocalizer["Regulator.SignIn"]</a>
 				          }
 			          </li>
 		          </ul>

--- a/src/FrontendAccountManagement.Web/assets/scss/application.scss
+++ b/src/FrontendAccountManagement.Web/assets/scss/application.scss
@@ -5,6 +5,10 @@ $govuk-assets-path: '/manage-account/';
 @import './components/language_toggle';
 @import './components/ordered_list';
 
+.govuk-tag {
+    max-width: inherit !important;
+}
+
 .govuk-notification-banner__heading {
     word-wrap: break-word;
 }

--- a/src/FrontendAccountManagement.Web/gulpfile.js
+++ b/src/FrontendAccountManagement.Web/gulpfile.js
@@ -47,7 +47,7 @@ gulp.task('copy-custom-javascript', () => {
 });
 
 gulp.task('copy-custom-images', () => {
-    return gulp.src('assets/images/*')
+    return gulp.src('assets/images/*', {encoding:false})
         .pipe(gulp.dest('wwwroot/images', { overwrite: true }));
 });
 


### PR DESCRIPTION
- Added govuk-tag override that ensures that the tag doesnt wrap
- Updated headings where a fieldset class was being used outside of a fieldset element, using the correct govuk-heading-l css class instead
- Updated service navigation links to the correct styling. 